### PR TITLE
fix broken test

### DIFF
--- a/doc/request_test.go
+++ b/doc/request_test.go
@@ -16,7 +16,7 @@ func (t *suite) TestNewRequest_RequestBodyIsCorrectlyCopied() {
 	apiReq, err := NewRequest(req)
 	t.Must(t.Nil(err))
 
-	t.Equal(string(apiReq.Body), testRequestBody)
+	t.Equal(string(apiReq.Body.Content), testRequestBody)
 }
 
 func (t *suite) TestNewRequest_OriginalRequestBodyDoesNotChange() {

--- a/doc/response_test.go
+++ b/doc/response_test.go
@@ -19,7 +19,7 @@ func (t *suite) TestNewResponse_ResponseBodyIsCorrectlyCopied() {
 
 	apiResp := NewResponse(w)
 
-	t.Equal(string(apiResp.Body), testResponseBody)
+	t.Equal(string(apiResp.Body.Content), testResponseBody)
 }
 
 func (t *suite) TestNewResponse_OriginalResponseBodyDoesNotChange() {


### PR DESCRIPTION
Fixes the tests by using `Body.Content` instead of `Body` which is a struct. 
