### PR TITLE
use headers to provide title and description params

### DIFF
--- a/doc/action.go
+++ b/doc/action.go
@@ -67,6 +67,12 @@ func NewAction(method, handlerName string) (*Action, error) {
 }
 
 func (a *Action) AddRequest(req *Request, resp *Response) {
+	if req.Description != "" {
+		a.Description = req.Description
+	}
+	if req.Title != "" {
+		a.Title = req.Title
+	}
 	req.Response = resp
 	a.Requests = append(a.Requests, req)
 }

--- a/doc/request.go
+++ b/doc/request.go
@@ -18,11 +18,21 @@ func init() {
 	requestTmpl = template.Must(template.New("request").Parse(requestFmt))
 }
 
+const (
+	descriptionHeader = "X-Test2Doc-Description"
+	titleHeader       = "X-Test2Doc-Title"
+)
+
 type Request struct {
 	Header   *Header
 	Body     *Body
 	Method   string
 	Response *Response
+
+	// Headers which are pulled out of request
+	// to use for generating documentation.
+	Description string
+	Title       string
 
 	// TODO:
 	// Attributes
@@ -30,6 +40,14 @@ type Request struct {
 }
 
 func NewRequest(req *http.Request) (*Request, error) {
+	// pull test2doc headers out of request,
+	// then delete header so that it's not used
+	// in the actual request
+	desc := req.Header.Get(descriptionHeader)
+	req.Header.Del(descriptionHeader)
+	title := req.Header.Get(titleHeader)
+	req.Header.Del(titleHeader)
+
 	body1, body2, err := cloneBody(req.Body)
 	if err != nil {
 		return nil, err
@@ -41,9 +59,11 @@ func NewRequest(req *http.Request) (*Request, error) {
 	contentType := req.Header.Get("Content-Type")
 
 	return &Request{
-		Header: NewHeader(req.Header),
-		Body:   NewBody(b2bytes, contentType),
-		Method: req.Method,
+		Header:      NewHeader(req.Header),
+		Body:        NewBody(b2bytes, contentType),
+		Method:      req.Method,
+		Description: desc,
+		Title:       title,
 	}, nil
 }
 


### PR DESCRIPTION
 This PR adds the ability to set the `Description` and `Title` used by test2doc by setting custom request headers. 

Sometimes the HTTP Handler is not a function or method in the code, but is created using a factory function.