### PR TITLE
correctly parse JSON Content-Type

### DIFF
--- a/doc/body.go
+++ b/doc/body.go
@@ -1,6 +1,9 @@
 package doc
 
-import "text/template"
+import (
+	"strings"
+	"text/template"
+)
 
 var (
 	bodyTmpl *template.Template
@@ -35,7 +38,7 @@ func (b *Body) Render() string {
 }
 
 func (b *Body) FormattedStr() string {
-	if b.ContentType == "application/json" {
+	if strings.HasPrefix(b.ContentType, "application/json") {
 		return b.FormattedJSON()
 	}
 	return string(b.Content)


### PR DESCRIPTION
support Content-Type headers which have `;charset=...` 
