### PR TITLE
Take handler info from the top most function in the package

### DIFF
--- a/test/responsewriter.go
+++ b/test/responsewriter.go
@@ -60,6 +60,9 @@ func (rw *ResponseWriter) setHandlerInfo() {
 
 		fnInPkg = parse.IsFuncInPkg(fnName)
 		if sawPkg && !fnInPkg {
+			pc, file, _, ok = runtime.Caller(i - 1)
+			fn := runtime.FuncForPC(pc)
+			fnName = fn.Name()
 			break
 		}
 

--- a/test/responsewriter.go
+++ b/test/responsewriter.go
@@ -45,9 +45,9 @@ func (rw *ResponseWriter) setHandlerInfo() {
 
 	var pc uintptr
 	var file, fnName string
-	var ok bool
+	var ok, fnInPkg, sawPkg bool
 
-	// iterate until we find a func in this pkg (the handler)
+	// iterate until we find the top level func in this pkg (the handler)
 	for i < max {
 		pc, file, _, ok = runtime.Caller(i)
 		if !ok {
@@ -58,10 +58,12 @@ func (rw *ResponseWriter) setHandlerInfo() {
 		fn := runtime.FuncForPC(pc)
 		fnName = fn.Name()
 
-		if parse.IsFuncInPkg(fnName) {
+		fnInPkg = parse.IsFuncInPkg(fnName)
+		if sawPkg && !fnInPkg {
 			break
 		}
 
+		sawPkg = fnInPkg
 		i++
 	}
 


### PR DESCRIPTION
Handler info is taken from the first function in the package (deepest one in the stack). In my case it's an internal function to DRY up my handlers. 

This PR propose to grab that info from the top level function in the package instead (earliest in the stack).

