### PR TITLE
Enable to write a snake case value to the parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Test2doc will generate markdown documentation for this endpoint in the [API Blue
 ## /widgets/{id}
 
 + Parameters
-    + id: `2` (number)
+    + `id`: `2` (number)
 
 ### Get Widget [GET]
 retrieves a single Widget

--- a/api-blueprint-spec.txt
+++ b/api-blueprint-spec.txt
@@ -22,7 +22,7 @@ HOST: https://<api-domain.net>
 <description>
 
 + Parameters
-    + <param>: `<example value>` (<type, eg. string>) - <description>
+    + `<param>`: `<example value>` (<type, eg. string>) - <description>
 
 + Model (<content-type, eg. application/json>)
     
@@ -77,7 +77,7 @@ HOST: https://<api-domain.net>
 <description>
 
 + Parameters
-    + param (<required|optional>, <type, eg. number>, `<example value, eg. 1>`) ... <description>
+    + `param` (<required|optional>, <type, eg. number>, `<example value, eg. 1>`) ... <description>
 
 ### <request #1 title> [<request method, eg. PUT]
 <description>

--- a/doc/parameter.go
+++ b/doc/parameter.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	parameterTmpl *template.Template
-	parameterFmt  = `    + {{.Name}}: {{.Value.Quote}} ({{.Type.String}}){{with .Description}} - {{.}}{{end}}`
+	parameterFmt  = `    + {{.Name.Quote}}: {{.Value.Quote}} ({{.Type.String}}){{with .Description}} - {{.}}{{end}}`
 )
 
 func init() {
@@ -29,7 +29,7 @@ func init() {
 }
 
 type Parameter struct {
-	Name        string
+	Name        ParameterName
 	Description string
 	Value       ParameterValue
 	Type        ParameterType
@@ -41,7 +41,7 @@ type Parameter struct {
 
 func MakeParameter(key, val string) Parameter {
 	return Parameter{
-		Name:       key,
+		Name:       ParameterName(key),
 		Value:      ParameterValue(val),
 		Type:       paramType(val),
 		IsRequired: true, // assume anything in route URL is required
@@ -51,6 +51,16 @@ func MakeParameter(key, val string) Parameter {
 
 func (p *Parameter) Render() string {
 	return render(parameterTmpl, p)
+}
+
+type ParameterName string
+
+func (val ParameterName) Quote() (qval string) {
+	if len(val) > 0 {
+		qval = fmt.Sprintf("`%s`", string(val))
+	}
+
+	return
 }
 
 type ParameterValue string

--- a/doc/parameter_test.go
+++ b/doc/parameter_test.go
@@ -38,3 +38,18 @@ func TestQuoteParameterValue_EmptyValue(t *testing.T) {
 		t.Fatalf("expected 'string(val)' (%v) to equal 'quotedVal' (%v)", string(val), quotedVal)
 	}
 }
+
+func TestQuoteParameterName(t *testing.T) {
+	name := ParameterName("param-name")
+
+	quotedName := name.Quote()
+	if len(name)+2 != len(quotedName) {
+		t.Fatalf("expected 'len(name)+2' (%v) to equal 'len(quotedName)' (%v)", len(name)+2, len(quotedName))
+	}
+	if !strings.Contains(quotedName, string(name)) {
+		t.Fatalf("expected 'strings.Contains(quotedName, string(name))' (%v) be true", strings.Contains(quotedName, string(name)))
+	}
+	if quotedName[0] != quotedName[len(quotedName)-1] {
+		t.Fatalf("expected 'quotedName[0]' (%v) to equal 'quotedName[len(quotedName)-1]' (%v)", quotedName[0], quotedName[len(quotedName)-1])
+	}
+}

--- a/example/apiary.apib
+++ b/example/apiary.apib
@@ -10,7 +10,7 @@ REST API for all things foo/widget.
 ## /foos{?n}
 
 + Parameters
-    + n: `10` (number)
+    + `n`: `10` (number)
 
 ### Get Foos [GET]
 retrieves the collection of Foos
@@ -50,7 +50,7 @@ retrieves the collection of Foos
 ## /foos/{key}
 
 + Parameters
-    + key: `ABeeSee` (string)
+    + `key`: `ABeeSee` (string)
 
 ### Get Foo [GET]
 retrieves a single Foo
@@ -75,7 +75,7 @@ retrieves a single Foo
 ## /widgets/{id}
 
 + Parameters
-    + id: `2` (number)
+    + `id`: `2` (number)
 
 ### Get Widget [GET]
 retrieves a single Widget

--- a/example/foos/foos.apib
+++ b/example/foos/foos.apib
@@ -4,7 +4,7 @@
 ## /foos/{key}
 
 + Parameters
-    + key: `ABeeSee` (string)
+    + `key`: `ABeeSee` (string)
 
 ### Get Foo [GET]
 retrieves a single Foo
@@ -27,7 +27,7 @@ retrieves a single Foo
 ## /foos{?n}
 
 + Parameters
-    + n: `10` (number)
+    + `n`: `10` (number)
 
 ### Get Foos [GET]
 retrieves the collection of Foos

--- a/example/widgets/widgets.apib
+++ b/example/widgets/widgets.apib
@@ -90,7 +90,7 @@ adds a Widget to the collection
 ## /widgets/{id}
 
 + Parameters
-    + id: `hello` (string)
+    + `id`: `hello` (string)
 
 ### Get Widget [GET]
 retrieves a single Widget


### PR DESCRIPTION
This PR is a fix to solve the following problem.

https://github.com/apiaryio/api-blueprint/issues/311

`_`  is  reserved character. If the value contains underscore, it will not display properly.
Enclosing the name with backtick can solve the problem.